### PR TITLE
Devex UI decouple

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+logs/
+wildbook-data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,78 @@
+# Stage 1: Build Wildbook WAR
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+
+# Install build-essential, Node.js and npm
+# build-essential is needed for some native npm modules
+RUN apt-get update && \
+  apt-get install -y build-essential curl gnupg && \
+  curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+  apt-get install -y nodejs imagemagick rsync && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set working directory to the application root
+WORKDIR /app
+
+COPY local-repo /app/local-repo
+
+# Copy pom.xml and download Maven dependencies
+COPY pom.xml ./
+RUN mvn verify clean --fail-never
+
+COPY ./frontend /app/frontend
+COPY ./src/main/webapp/javascript /app/src/main/webapp/javascript
+
+WORKDIR /app/frontend
+ENV PUBLIC_URL=/react/
+ENV SITE_NAME="Wildbook"
+RUN npm install react-app-rewired
+RUN npm ci
+RUN npm run build
+RUN mkdir -p /app/src/main/webapp/react && rsync -a ./build/ /app/src/main/webapp/react/
+
+WORKDIR /app
+COPY . .
+# Build the WAR file, skipping tests and front end build for faster build
+ENV SKIP_FRONTEND_BUILD=true
+RUN mvn -T 4 clean install -DskipTests -Dmaven.antrun.skip=true
+
+
+# Stage 2: Deploy to Tomcat
+FROM tomcat:9.0.113-jre17-temurin-jammy
+
+# Install envsubst for environment variable substitution
+RUN apt-get update && apt-get install -y gettext-base imagemagick && rm -rf /var/lib/apt/lists/*
+
+
+# Create staging location for config files (seeded into mounted volume at runtime)
+RUN mkdir -p /opt/wildbook_seed/WEB-INF/classes/bundles
+
+# Create empty AnnotationLiteCache.json file with valid JSON to prevent startup warning
+# RUN echo '{}' > /usr/local/tomcat/webapps/wildbook_data_dir/WEB-INF/AnnotationLiteCache.json
+
+# Set environment variables for runtime configuration
+ENV JAVA_OPTS="-Djava.awt.headless=true -Xms4096m -Xmx4096m"
+
+# Copy config and bundle files to staging location (seeded into mounted volume at runtime)
+COPY --from=build /app/src/main/resources/bundles/ /opt/wildbook_seed/WEB-INF/classes/bundles/
+
+# Copy Docker-specific configuration files to staging
+COPY ./devops/development/.dockerfiles/tomcat/server.xml /usr/local/tomcat/conf/server.xml
+COPY ./devops/development/.dockerfiles/tomcat/watermark.png /usr/local/tomcat/watermark.png
+COPY ./devops/development/.dockerfiles/tomcat/IA-wbia.json /opt/wildbook_seed/WEB-INF/classes/bundles/IA.json
+COPY ./devops/development/.dockerfiles/tomcat/IA-wbia.properties /opt/wildbook_seed/WEB-INF/classes/bundles/IA.properties
+COPY ./devops/development/.dockerfiles/tomcat/commonConfiguration.properties /opt/wildbook_seed/WEB-INF/classes/bundles/commonConfiguration.properties
+COPY ./devops/development/.dockerfiles/tomcat/jdoconfig.properties.template /opt/wildbook_seed/WEB-INF/classes/bundles/jdoconfig.properties.template
+
+
+# Copy the built WAR file from the build stage to Tomcat's webapps directory as ROOT.war
+COPY --from=build /app/target/wildbook-*.war /usr/local/tomcat/webapps/ROOT.war
+
+# Copy startup script
+COPY ./devops/development/.dockerfiles/tomcat/wildbook-start.sh /usr/local/bin/wildbook-start.sh
+RUN chmod +x /usr/local/bin/wildbook-start.sh
+
+# Expose the port on which Tomcat will run
+EXPOSE 8080
+
+# Use custom startup script
+CMD ["/usr/local/bin/wildbook-start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,61 +1,37 @@
-# Stage 1: Build Wildbook WAR
-FROM maven:3.9.6-eclipse-temurin-21 AS build
+# Stage 1: Build Wildbook WAR (Java only)
+FROM maven:3.9.6-eclipse-temurin-21 AS java-build
 
-# Install build-essential, Node.js and npm
-# build-essential is needed for some native npm modules
 RUN apt-get update && \
   apt-get install -y build-essential curl gnupg && \
   curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
   apt-get install -y nodejs rsync && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Set working directory to the application root
 WORKDIR /app
 
 COPY local-repo /app/local-repo
-
-# Copy pom.xml and download Maven dependencies
 COPY pom.xml ./
 RUN mvn verify clean --fail-never
 
-COPY ./frontend /app/frontend
-COPY ./src/main/webapp/javascript /app/src/main/webapp/javascript
+# Copy the entire project (frontend source is harmless now that the pom.xml plugin is removed)
+COPY . /app
 
-WORKDIR /app/frontend
-ENV PUBLIC_URL=/react/
-ENV SITE_NAME="Wildbook"
-RUN npm install react-app-rewired
-RUN npm ci
-RUN npm run build
-RUN mkdir -p /app/src/main/webapp/react && rsync -a ./build/ /app/src/main/webapp/react/
+# Remove any stale React build artifacts from previous hybrid builds
+RUN rm -rf /app/src/main/webapp/react
 
-WORKDIR /app
-COPY . .
-# Build the WAR file, skipping tests and front end build for faster build
 ENV SKIP_FRONTEND_BUILD=true
 RUN mvn -T 4 clean install -DskipTests -Dmaven.antrun.skip=true
-
 
 # Stage 2: Deploy to Tomcat
 FROM tomcat:9.0.113-jre17-temurin-jammy
 
-# Install envsubst for environment variable substitution
 RUN apt-get update && apt-get install -y gettext-base imagemagick && rm -rf /var/lib/apt/lists/*
 
-
-# Create staging location for config files (seeded into mounted volume at runtime)
 RUN mkdir -p /opt/wildbook_seed/WEB-INF/classes/bundles
 
-# Create empty AnnotationLiteCache.json file with valid JSON to prevent startup warning
-# RUN echo '{}' > /usr/local/tomcat/webapps/wildbook_data_dir/WEB-INF/AnnotationLiteCache.json
-
-# Set environment variables for runtime configuration
 ENV JAVA_OPTS="-Djava.awt.headless=true -Xms4096m -Xmx4096m"
 
-# Copy config and bundle files to staging location (seeded into mounted volume at runtime)
-COPY --from=build /app/src/main/resources/bundles/ /opt/wildbook_seed/WEB-INF/classes/bundles/
-
-# Copy Docker-specific configuration files to staging
+COPY --from=java-build /app/src/main/resources/bundles/ /opt/wildbook_seed/WEB-INF/classes/bundles/
 COPY ./devops/development/.dockerfiles/tomcat/server.xml /usr/local/tomcat/conf/server.xml
 COPY ./devops/development/.dockerfiles/tomcat/watermark.png /usr/local/tomcat/watermark.png
 COPY ./devops/development/.dockerfiles/tomcat/IA-wbia.json /opt/wildbook_seed/WEB-INF/classes/bundles/IA.json
@@ -63,16 +39,10 @@ COPY ./devops/development/.dockerfiles/tomcat/IA-wbia.properties /opt/wildbook_s
 COPY ./devops/development/.dockerfiles/tomcat/commonConfiguration.properties /opt/wildbook_seed/WEB-INF/classes/bundles/commonConfiguration.properties
 COPY ./devops/development/.dockerfiles/tomcat/jdoconfig.properties.template /opt/wildbook_seed/WEB-INF/classes/bundles/jdoconfig.properties.template
 
+COPY --from=java-build /app/target/wildbook-*.war /usr/local/tomcat/webapps/ROOT.war
 
-# Copy the built WAR file from the build stage to Tomcat's webapps directory as ROOT.war
-COPY --from=build /app/target/wildbook-*.war /usr/local/tomcat/webapps/ROOT.war
-
-# Copy startup script
 COPY ./devops/development/.dockerfiles/tomcat/wildbook-start.sh /usr/local/bin/wildbook-start.sh
 RUN chmod +x /usr/local/bin/wildbook-start.sh
 
-# Expose the port on which Tomcat will run
 EXPOSE 8080
-
-# Use custom startup script
 CMD ["/usr/local/bin/wildbook-start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM maven:3.9.6-eclipse-temurin-21 AS build
 RUN apt-get update && \
   apt-get install -y build-essential curl gnupg && \
   curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
-  apt-get install -y nodejs imagemagick rsync && \
+  apt-get install -y nodejs rsync && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Set working directory to the application root

--- a/README.md
+++ b/README.md
@@ -9,75 +9,54 @@ Wildbook is an open source software framework to support mark-recapture, molecul
 - provides a platform for animal biometrics that supports easy data access and facilitates matching application deployment for multiple species
 
 ## Getting Started with Wildbook
-Wildbook is a long-standing tool that support a wide variety of researchers and species. The Wild Me team is working on revamping the tool as a true open source project, so if you have ideas and are excited to help, reach out to us on the [Wild Me Development Discord](https://discord.gg/zw4tr3RE4R)!
 
-## Pull Request Workflow
-All contributions should be made from a fork off of the Wildbook repo. While there are a number of repositories for specific Wildbook communities, large scale development is driven from the main repository. 
+Wildbook is a long-standing tool that support a wide variety of researchers and species. 
+The Wild Me team is working on revamping the tool as a true open source project, so if you have ideas and are excited to help, reach out to us on the [Wild Me Development Discord](https://discord.gg/zw4tr3RE4R)!
 
-### Fork Wildbook
-To start, you will need to be signed in to your GitHub account, have admin access to your OS's terminal, and have Git installed.
-1. From your browser, in the top right corner of the [Wildbook repo](https://github.com/WildMeOrg/Wildbook), click the **Fork** button. Confirm to be redirected to your own fork (check the url for your USERNAME in the namespace).
-1. In your terminal, enter the command `git clone https://github.com/USERNAME/Wildbook`
-1. Once the Wildbook directory becomes available in your working directory, move to it with the command `cd Wildbook`
-1. Add a reference to the original repo, denoting it as the upstream repo.
+### Quick Start with Docker
+
+The easiest way to run Wildbook locally is with Docker Compose. This builds the full application (including the frontend) and starts all required services.
+
+**Prerequisites:** Docker and Docker Compose installed on your system.
+
+```bash
+# 1. Create your .env file from the repo root's .env defaults
+#    (defaults already provided no changes needed for local dev)
+
+cp devops/development/_env.template .env
+
+# 2. Start all services
+
+docker compose up -d
 ```
-git remote add upstream https://github.com/WildMeOrg/Wildbook
-git fetch upstream
+
+The first build will take a few minutes as it compiles the Java project and builds the React frontend. Subsequent starts are faster.
+
+**What's running:**
+
+| Service      | Description                      | Port                   |
+| ------------ | -------------------------------- | ---------------------- |
+| `wildbook`   | Tomcat with Wildbook application | `8080`                 |
+| `db`         | PostgreSQL database              | `5433`                 |
+| `opensearch` | Search index                     | `9200`                 |
+| `mailhog`    | Email capture for dev            | SMTP `1025`, UI `8025` |
+| `wbia`       | Image analysis (Wildbook IA)     | `82`                   |
+
+Once started, open **http://localhost:8080** in your browser. Default login: `tomcat` / `tomcat123`.
+
+Outbound emails are captured by MailHog. View them at **http://localhost:8025**.
+
+**Note:** OpenSearch requires a higher `vm.max_map_count` on Linux. Run once:
+
+```bash
+sudo sysctl -w vm.max_map_count=262144
 ```
+### Legacy development
+For legacy docker build and instructions on locally building the .war file see [`devops/README.md`](devops/README.md) for detailed instructions.
 
-### Create Local Branch
-You will want to work in a branch when doing any feature development you want to provide to the original project.
-1. Verify you are on the main branch. The branch you have checked out will be used as the base for your new branch, so you typically want to start from main.
-`git checkout main`
-1. Create your feature branch. It can be helpful to include the issue number (ISSUENUMBER) you are working to address.
-`git branch ISSUENUMBER-FEATUREBRANCHNAME`
-1. Change to your feature branch so your changes are grouped together.
-`git checkout ISSUENUMBER-FEATUREBRANCHNAME`
-1. Update your branch (this is not needed if you just created new branch, but is a good habit to get into).
-` git pull upstream main`
+### Frontend-Only Development
 
-### Set Up Development Environment with Docker
-For easiest development, you will need to set up your development environment to work with Docker. See [`devops/README.md`](devops/README.md) for detailed instructions.
-
-### Making Local Changes
-Make the code changes necessary for the issue you're working on. You will need to either redeploy your war file (see [`devops/README.md`](devops/README.md)) or redeploy your front end directly (see [`frontend.README.md`](frontend/README.md)) for testing locally. 
-
-The following git commands may prove useful.
-* `git log`: lastest commits of current branch
-* `git status`: current staged and unstaged modifications
-* `git diff --staged`:  the differences between the staging area and the last commit
-* `git add <filename>: add files that have changes to staging in preparation for commit
-* `git commit`: commits the stagged files, opens a text editor for you to write a commit log
-
-### Unit Tests
-We are working on building up test coverage. Current requirements are:
-* Do not drop the percentage of test coverage (exceptions will be made for large scale changes on case-by-case basis)
-* Do not break existing tests
-
-See [test coverage guidelines](src/test/README.md) for how to develop your tests.
-
-### Submit PR
-Up to this point, all changes have been done to your local copy of Wildbook. You need to push the new commits to a remote branch to start the PR process.
-
-1. Now's the time clean up your PR if you choose to squash commits, but this is not required. If you're looking for more information on these practices, see this [pull request tutorial](https://yangsu.github.io/pull-request-tutorial/).
-1. Push to the remote version of your branch ` git push <remote> <local branch>`
-`git push origin ISSUENUMBER-FEATUREBRANCHNAME`
-1. When prompted, provide your username and GitHub Personal Access Token. If you do not have a GitHub Personal Access Token, or do not have one with the correct permissions for your newly forked repository, you will need to [create a Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
-1. Check the fork's page on GitHub to verify that you see a new branch with your added commits. You should see a line saying "This branch is X commits ahead" and a **Pull request** link. 
-1. Click the **Pull request** link to open a form that says "Able to merge". (If it says there are merge conflicts, go the  for help).
-1. Use an explicit title for the PR and provide details in the comment area. Details can include text, or images, and should provide details as to what was done and why design decisions were made.
-1. Click **Create a pull request**. 
- 
-### Respond to feedback
-At this point, it's on us to get you feedback on your submission! Someone from the Wild Me team will review the project and provide any feedback that may be necessary. If changes are recommended, you'll need to checkout the branch you were working from, update the branch, and make these changes locally.
-
-1. `git checkout ISSUENUMBER-FEATUREBRANCHNAME`
-1. `git pull upstream main`
-1. Make required changes
-1. `git add <filename>` for all files impacted by changes
-1. Determine which method would be most appropriate for updating your PR  
-  * `git commit --ammend` if the changes are small stylistic changes
-  * `git commit` if the changes involved significant rework and require additional details
+If you are only making changes to the React frontend, see [`frontend/README.md`](frontend/README.md) for a faster rebuild cycle.
 
 ## Machine Learning in Wildbook
 
@@ -90,14 +69,15 @@ Wild Me (wildme.org) engineering staff provide support for Wildbook. You can con
 We provide support during regular office hours on Mondays and Tuesdays.
 
 ## Support resources
-* User documentation is available at [Wild Me Documentation](http://wildbook.docs.wildme.org)
-* For user support, visit the [Wild Me Community Forum](https://community.wildme.org)
-* For contribution guidelines, visit [Wildbook Code Contribution Guidelines](https://wildbook.docs.wildme.org/contribute/code-guide.html)
-* For developer support, visit the [Wild Me Development Discord](https://discord.gg/zw4tr3RE4R)
-* Email the team at opensource@wildme.org
+
+- User documentation is available at [Wild Me Documentation](http://wildbook.docs.wildme.org)
+- For user support, visit the [Wild Me Community Forum](https://community.wildme.org)
+- For contribution guidelines, visit [Wildbook Code Contribution Guidelines](https://wildbook.docs.wildme.org/contribute/code-guide.html)
+- For developer support, visit the [Wild Me Development Discord](https://discord.gg/zw4tr3RE4R)
+- Email the team at opensource@wildme.org
 
 ## History
-Wildbook started as a collaborative software platform for globally-coordinated whale shark (Rhincodon typus ) research as deployed in the Wildbook for Whale Sharks (now part of http://www.sharkbook.ai). After many requests to use our software outside of whale shark research, it is now an open source, community-maintained standard for mark-recapture studies.
 
+Wildbook started as a collaborative software platform for globally-coordinated whale shark (Rhincodon typus ) research as deployed in the Wildbook for Whale Sharks (now part of http://www.sharkbook.ai). After many requests to use our software outside of whale shark research, it is now an open source, community-maintained standard for mark-recapture studies.
 
 Wildbook is a trademark of [Conservation X Labs](https://conservationxlabs.com/), a 501(c)(3) non-profit organization, and is supported by the [Wild Me](https://wildme.org) team.

--- a/devops/development/.dockerfiles/caddy/Caddyfile
+++ b/devops/development/.dockerfiles/caddy/Caddyfile
@@ -17,12 +17,15 @@
     @isReactBare path /react
     redir @isReactBare /react/ permanent
 
-    # React static files + SPA fallback
-    # Strips /react/ prefix so /react/static/... maps to /srv/react/static/...
-    handle_path /react/* {
-        root * /srv/react
-        try_files {path} {path}/ /index.html
-        file_server
+    # React CRA dev server (livereload via WebSocket)
+    # Using handle NOT handle_path — CRA dev server with PUBLIC_URL=/react/
+    # needs to receive the full path including /react/ prefix.
+    handle /react* {
+        reverse_proxy frontend:3000 {
+            header_up Host {host}
+            header_up X-Forwarded-For {remote}
+            header_up X-Forwarded-Proto {scheme}
+        }
     }
 
     # Legacy JSPs and everything else -> Tomcat

--- a/devops/development/.dockerfiles/caddy/Caddyfile
+++ b/devops/development/.dockerfiles/caddy/Caddyfile
@@ -1,0 +1,41 @@
+:80 {
+    # API routes -> Tomcat (NO path stripping)
+    handle /api/* {
+        reverse_proxy wildbook:8080 {
+            header_up Host {host}
+            header_up X-Forwarded-For {remote}
+            header_up X-Forwarded-Proto {scheme}
+
+            transport http {
+                dial_timeout 1200s
+                response_header_timeout 1200s
+            }
+        }
+    }
+
+    # Redirect /react to /react/ so handle_path matches
+    @isReactBare path /react
+    redir @isReactBare /react/ permanent
+
+    # React static files + SPA fallback
+    # Strips /react/ prefix so /react/static/... maps to /srv/react/static/...
+    handle_path /react/* {
+        root * /srv/react
+        try_files {path} {path}/ /index.html
+        file_server
+    }
+
+    # Legacy JSPs and everything else -> Tomcat
+    handle {
+        reverse_proxy wildbook:8080 {
+            header_up Host {host}
+            header_up X-Forwarded-For {remote}
+            header_up X-Forwarded-Proto {scheme}
+
+            transport http {
+                dial_timeout 1200s
+                response_header_timeout 1200s
+            }
+        }
+    }
+}

--- a/devops/development/.dockerfiles/caddy/Dockerfile
+++ b/devops/development/.dockerfiles/caddy/Dockerfile
@@ -1,0 +1,22 @@
+# Stage 1: Build frontend assets independently
+FROM node:18 AS frontend-build
+
+WORKDIR /frontend
+
+COPY ./frontend/package*.json ./
+COPY ./frontend/. ./
+
+# Tablesorter assets referenced by frontend CSS via relative paths
+COPY ./src/main/webapp/javascript/tablesorter/ /src/main/webapp/javascript/tablesorter/
+
+ENV PUBLIC_URL=/react/
+ENV SITE_NAME="Wildbook"
+RUN npm install react-app-rewired
+RUN npm ci
+RUN npm run build
+
+# Stage 2: Caddy proxy with built React static files
+FROM caddy:2-alpine
+
+COPY --from=frontend-build /frontend/build /srv/react
+COPY devops/development/.dockerfiles/caddy/Caddyfile /etc/caddy/Caddyfile

--- a/devops/development/.dockerfiles/caddy/Dockerfile
+++ b/devops/development/.dockerfiles/caddy/Dockerfile
@@ -1,22 +1,3 @@
-# Stage 1: Build frontend assets independently
-FROM node:18 AS frontend-build
-
-WORKDIR /frontend
-
-COPY ./frontend/package*.json ./
-COPY ./frontend/. ./
-
-# Tablesorter assets referenced by frontend CSS via relative paths
-COPY ./src/main/webapp/javascript/tablesorter/ /src/main/webapp/javascript/tablesorter/
-
-ENV PUBLIC_URL=/react/
-ENV SITE_NAME="Wildbook"
-RUN npm install react-app-rewired
-RUN npm ci
-RUN npm run build
-
-# Stage 2: Caddy proxy with built React static files
 FROM caddy:2-alpine
-
-COPY --from=frontend-build /frontend/build /srv/react
 COPY devops/development/.dockerfiles/caddy/Caddyfile /etc/caddy/Caddyfile
+EXPOSE 80

--- a/devops/development/.dockerfiles/frontend/Dockerfile
+++ b/devops/development/.dockerfiles/frontend/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:18
+
+WORKDIR /frontend
+
+RUN npm install -g serve
+
+COPY ./frontend/package*.json ./
+RUN npm ci
+
+COPY ./frontend/. ./
+
+# Tablesorter assets referenced by frontend CSS via relative paths
+COPY ./src/main/webapp/javascript/tablesorter/ /src/main/webapp/javascript/tablesorter/
+
+ENV PUBLIC_URL=/react/
+ENV SITE_NAME="Wildbook"
+
+EXPOSE 3000
+
+# Development: CRA dev server with livereload
+CMD ["npm", "start"]

--- a/devops/development/.dockerfiles/tomcat/jdoconfig.properties.template
+++ b/devops/development/.dockerfiles/tomcat/jdoconfig.properties.template
@@ -1,0 +1,27 @@
+#DataNucleus parameters for object persistence - Docker Configuration with Environment Variables
+
+# PostgreSQL connection for Docker environment
+datanucleus.ConnectionDriverName=org.postgresql.Driver
+datanucleus.ConnectionURL=${WILDBOOK_DB_CONNECTION_URL}
+
+javax.jdo.PersistenceManagerFactoryClass = org.datanucleus.api.jdo.JDOPersistenceManagerFactory
+datanucleus.ConnectionUserName = ${WILDBOOK_DB_USER}              
+datanucleus.ConnectionPassword = ${WILDBOOK_DB_PASSWORD}
+datanucleus.schema.autoCreateAll = true
+datanucleus.NontransactionalRead = true
+datanucleus.Multithreaded = true
+datanucleus.RestoreValues = true
+datanucleus.storeManagerType = rdbms
+datanucleus.maxFetchDepth = -1
+datanucleus.cache.collections.lazy = false
+
+#connection pooling
+datanucleus.connectionPoolingType = dbcp2
+
+# DBCP2 Pooling of Connections
+datanucleus.connectionPool.maxIdle=10
+datanucleus.connectionPool.minIdle=5
+datanucleus.connectionPool.maxActive=30
+datanucleus.connectionPool.maxWait=-1
+datanucleus.connectionPool.testSQL=SELECT 1
+datanucleus.connectionPool.timeBetweenEvictionRunsMillis=240000

--- a/devops/development/.dockerfiles/tomcat/server.xml
+++ b/devops/development/.dockerfiles/tomcat/server.xml
@@ -161,7 +161,7 @@
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" deployOnStartup="false" autoDeploy="false">
 
-	      <Context path="" docBase="wildbook"></Context>
+        <Context path="" docBase="ROOT"></Context>
 
 	      <Context docBase="/usr/local/tomcat/webapps/wildbook_data_dir" path="/wildbook_data_dir" />
 

--- a/devops/development/.dockerfiles/tomcat/wildbook-start.sh
+++ b/devops/development/.dockerfiles/tomcat/wildbook-start.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Set defaults for database configuration
+export WILDBOOK_DB_CONNECTION_URL=${WILDBOOK_DB_CONNECTION_URL:-"jdbc:postgresql://db:5432/wildbook"}
+export WILDBOOK_DB_USER=${WILDBOOK_DB_USER:-"wildbook"}
+export WILDBOOK_DB_PASSWORD=${WILDBOOK_DB_PASSWORD:-"development"}
+
+# Seed config files from staging into mounted wildbook_data_dir on first boot
+DATA_DIR=/usr/local/tomcat/webapps/wildbook_data_dir
+SEED_DIR=/opt/wildbook_seed
+
+if [ ! -f "$DATA_DIR/WEB-INF/classes/bundles/commonConfiguration.properties" ]; then
+  echo "Seeding configuration into $DATA_DIR..."
+  mkdir -p "$DATA_DIR/WEB-INF/classes/bundles"
+  cp -a "$SEED_DIR/." "$DATA_DIR/"
+fi
+
+# Create symlink for legacy path compatibility
+mkdir -p /data
+ln -sf "$DATA_DIR" /data/wildbook_data_dir
+mkdir -p "$DATA_DIR/WEB-IN"
+
+# Create required runtime directories on persisted volume
+mkdir -p "$DATA_DIR/encounters"
+mkdir -p "$DATA_DIR/users"
+mkdir -p "$DATA_DIR/upload"
+
+# Substitute environment variables in jdoconfig.properties
+envsubst < "$DATA_DIR/WEB-INF/classes/bundles/jdoconfig.properties.template" > "$DATA_DIR/WEB-INF/classes/bundles/jdoconfig.properties"
+
+# Fix containerName for WBIA communication
+sed -i 's/^containerName=.*/containerName=wildbook/' "$DATA_DIR/WEB-INF/classes/bundles/commonConfiguration.properties"
+
+# Override SMTP host for MailHog
+sed -i 's/^mailHost=.*/mailHost=mailhog/' "$DATA_DIR/WEB-INF/classes/bundles/commonConfiguration.properties"
+
+# Start Tomcat
+exec catalina.sh run

--- a/devops/development/.dockerfiles/tomcat/wildbook-start.sh
+++ b/devops/development/.dockerfiles/tomcat/wildbook-start.sh
@@ -19,6 +19,9 @@ mkdir -p /data
 ln -sf "$DATA_DIR" /data/wildbook_data_dir
 mkdir -p "$DATA_DIR/WEB-IN"
 
+# Symlink legacy "wildbook" context to ROOT (watermark path, etc.)
+ln -sf /usr/local/tomcat/webapps/ROOT /usr/local/tomcat/webapps/wildbook
+
 # Create required runtime directories on persisted volume
 mkdir -p "$DATA_DIR/encounters"
 mkdir -p "$DATA_DIR/users"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - "1025:1025"  # SMTP port
       - "8025:8025"  # Web UI port
 
- networks:
+networks:
   intranet:
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,144 @@
+services:
+  db:
+    image: postgres:13.4
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+    labels:
+      - autoheal=true
+    user: postgres
+    volumes:
+      - db-pgdata-var:/var/lib/postgresql/data
+      # DB initialization scripts
+      - ./devops/development/.dockerfiles/db/initdb.d/:/docker-entrypoint-initdb.d/
+      - ./devops/development/.dockerfiles/db/postgresql.conf:/etc/postgresql/postgresql.conf
+    networks:
+      - intranet
+    ports:
+      # development exposure, not exposed in production
+      - 5433:5432
+    command: -c config_file=/etc/postgresql/postgresql.conf
+    env_file: .env
+    environment:
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      WBIA_DB_NAME: "${WBIA_DB_NAME}"
+      WBIA_DB_USER: "${WBIA_DB_USER}"
+      WBIA_DB_PASSWORD: "${WBIA_DB_PASSWORD}"
+      WILDBOOK_DB_NAME: "${WILDBOOK_DB_NAME}"
+      WILDBOOK_DB_USER: "${WILDBOOK_DB_USER}"
+      WILDBOOK_DB_PASSWORD: "${WILDBOOK_DB_PASSWORD}"
+
+  wildbook:
+    build: .
+    depends_on:
+      db:
+        condition: service_healthy
+    labels:
+      - autoheal=true
+    volumes:
+      # Persist uploaded images and data on host filesystem
+      - "./wildbook-data:/usr/local/tomcat/webapps/wildbook_data_dir"
+      - "./logs/:/usr/local/tomcat/logs/"
+    networks:
+      - intranet
+    ports:
+      - "8080:8080"
+    env_file: .env
+    environment:
+      SITE_NAME: "${SITE_NAME:-wildbook}"
+      PUBLIC_URL: "${PUBLIC_URL:-/react/}"
+      # Admin user created on startup,
+      # https://github.com/WildMeOrg/Wildbook/commit/6d65e70e43691f1b281bb76edf151e5c7cdb7403
+      # JAVA_OPTS from old-world wildbook, which gives us 4G heap memory
+      JAVA_OPTS: "-Djava.awt.headless=true -Xms4096m -Xmx4096m"
+
+  opensearch:
+    image: opensearchproject/opensearch:2.15.0
+    healthcheck:
+      test: [ "CMD-SHELL", "curl --silent --fail 127.0.0.1:9200/_cluster/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+    labels:
+      - autoheal=true
+    volumes:
+      - opensearch-var1:/usr/share/opensearch/data
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    networks:
+      - intranet
+    ports:
+      # development exposure, not exposed in production
+      - 9200:9200
+      - 9300:9300
+    env_file: .env
+    environment:
+      - plugins.security.disabled=true
+      - node.name=opensearch
+      #- discovery.seed_hosts=elasticsearch2,elasticsearch3
+      #- cluster.initial_master_nodes=elasticsearch,elasticsearch2,elasticsearch3
+      #- discovery.seed_hosts=opensearch2
+      - cluster.initial_master_nodes=opensearch
+      - bootstrap.memory_lock=true
+      - cluster.routing.allocation.disk.threshold_enabled=${ES_THRESHOLD:-true}
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD}"
+
+  # MailHog for development email testing
+  mailhog:
+    image: mailhog/mailhog:latest
+    networks:
+      - intranet
+    ports:
+      - "1025:1025"  # SMTP port
+      - "8025:8025"  # Web UI port
+
+  wbia:
+    # https://github.com/WildMeOrg/wildbook-ia
+    image: wildme/wbia:nightly
+    command: ["--db-uri", "${WBIA_DB_URI}"]
+    depends_on:
+      db:
+        condition: service_healthy
+    # healthcheck:  # WBIA defines it's own health check and is already labeled for autoheal
+    # labels:
+    #   - autoheal=true
+    volumes:
+      - wbia-database-var:/data/db
+      - wbia-cache-var:/cache
+    networks:
+      - intranet
+    ports:
+      - "82:5000"
+    env_file: .env
+    environment:
+      WBIA_DB_URI: "${WBIA_DB_URI}"
+      HOUSTON_CLIENT_ID: "${HOUSTON_CLIENT_ID}"
+      HOUSTON_CLIENT_SECRET: "${HOUSTON_CLIENT_SECRET}"
+
+  autoheal:
+    image: willfarrell/autoheal
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: "autoheal"
+      AUTOHEAL_INTERVAL: 15
+      AUTOHEAL_START_PERIOD: 600
+      AUTOHEAL_DEFAULT_STOP_TIMEOUT: 60
+    restart: always
+
+networks:
+  intranet:
+
+volumes:
+  db-pgdata-var:
+  wildbook-var:
+  wildbook-data:
+  opensearch-var1:
+  opensearch-var2:
+  wbia-database-var:
+  wbia-cache-var:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,26 @@ services:
       - intranet
     depends_on:
       - wildbook
+      - frontend
+
+  frontend:
+    build:
+      context: .
+      dockerfile: devops/development/.dockerfiles/frontend/Dockerfile
+    volumes:
+      - ./frontend/src:/frontend/src
+      - ./frontend/config-overrides.js:/frontend/config-overrides.js
+      - ./src/main/webapp/javascript/tablesorter:/src/main/webapp/javascript/tablesorter
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+      - DANGEROUSLY_DISABLE_HOST_CHECK=true
+      - WDS_SOCKET_PORT=3000
+    ports:
+      - "3000:3000"
+    networks:
+      - intranet
+    depends_on:
+      - wildbook
 
   db:
     image: postgres:13.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,15 @@
 services:
+  proxy:
+    build:
+      context: .
+      dockerfile: devops/development/.dockerfiles/caddy/Dockerfile
+    ports:
+      - "80:80"
+    networks:
+      - intranet
+    depends_on:
+      - wildbook
+
   db:
     image: postgres:13.4
     healthcheck:
@@ -38,8 +49,9 @@ services:
       - "./logs/:/usr/local/tomcat/logs/"
     networks:
       - intranet
-    ports:
-      - "8080:8080"
+    # Port 8080 is no longer bound to the host; Caddy proxies to it internally.
+    # ports:
+    #   - "8080:8080"
     env_file: .env
     environment:
       SITE_NAME: "${SITE_NAME:-wildbook}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
-    labels:
-      - autoheal=true
     user: postgres
     volumes:
       - db-pgdata-var:/var/lib/postgresql/data
@@ -17,7 +15,6 @@ services:
     networks:
       - intranet
     ports:
-      # development exposure, not exposed in production
       - 5433:5432
     command: -c config_file=/etc/postgresql/postgresql.conf
     env_file: .env
@@ -35,8 +32,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    labels:
-      - autoheal=true
     volumes:
       # Persist uploaded images and data on host filesystem
       - "./wildbook-data:/usr/local/tomcat/webapps/wildbook_data_dir"
@@ -61,8 +56,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
-    labels:
-      - autoheal=true
     volumes:
       - opensearch-var1:/usr/share/opensearch/data
     ulimits:
@@ -72,16 +65,12 @@ services:
     networks:
       - intranet
     ports:
-      # development exposure, not exposed in production
       - 9200:9200
       - 9300:9300
     env_file: .env
     environment:
       - plugins.security.disabled=true
       - node.name=opensearch
-      #- discovery.seed_hosts=elasticsearch2,elasticsearch3
-      #- cluster.initial_master_nodes=elasticsearch,elasticsearch2,elasticsearch3
-      #- discovery.seed_hosts=opensearch2
       - cluster.initial_master_nodes=opensearch
       - bootstrap.memory_lock=true
       - cluster.routing.allocation.disk.threshold_enabled=${ES_THRESHOLD:-true}
@@ -97,41 +86,7 @@ services:
       - "1025:1025"  # SMTP port
       - "8025:8025"  # Web UI port
 
-  wbia:
-    # https://github.com/WildMeOrg/wildbook-ia
-    image: wildme/wbia:nightly
-    command: ["--db-uri", "${WBIA_DB_URI}"]
-    depends_on:
-      db:
-        condition: service_healthy
-    # healthcheck:  # WBIA defines it's own health check and is already labeled for autoheal
-    # labels:
-    #   - autoheal=true
-    volumes:
-      - wbia-database-var:/data/db
-      - wbia-cache-var:/cache
-    networks:
-      - intranet
-    ports:
-      - "82:5000"
-    env_file: .env
-    environment:
-      WBIA_DB_URI: "${WBIA_DB_URI}"
-      HOUSTON_CLIENT_ID: "${HOUSTON_CLIENT_ID}"
-      HOUSTON_CLIENT_SECRET: "${HOUSTON_CLIENT_SECRET}"
-
-  autoheal:
-    image: willfarrell/autoheal
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      AUTOHEAL_CONTAINER_LABEL: "autoheal"
-      AUTOHEAL_INTERVAL: 15
-      AUTOHEAL_START_PERIOD: 600
-      AUTOHEAL_DEFAULT_STOP_TIMEOUT: 60
-    restart: always
-
-networks:
+ networks:
   intranet:
 
 volumes:

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -1,0 +1,66 @@
+## Pull Request Workflow
+All contributions should be made from a fork off of the Wildbook repo. While there are a number of repositories for specific Wildbook communities, large scale development is driven from the main repository. 
+
+### Fork Wildbook
+To start, you will need to be signed in to your GitHub account, have admin access to your OS's terminal, and have Git installed.
+1. From your browser, in the top right corner of the [Wildbook repo](https://github.com/WildMeOrg/Wildbook), click the **Fork** button. Confirm to be redirected to your own fork (check the url for your USERNAME in the namespace).
+1. In your terminal, enter the command `git clone https://github.com/USERNAME/Wildbook`
+1. Once the Wildbook directory becomes available in your working directory, move to it with the command `cd Wildbook`
+1. Add a reference to the original repo, denoting it as the upstream repo.
+```
+git remote add upstream https://github.com/WildMeOrg/Wildbook
+git fetch upstream
+```
+
+### Create Local Branch
+You will want to work in a branch when doing any feature development you want to provide to the original project.
+1. Verify you are on the main branch. The branch you have checked out will be used as the base for your new branch, so you typically want to start from main.
+`git checkout main`
+1. Create your feature branch. It can be helpful to include the issue number (ISSUENUMBER) you are working to address.
+`git branch ISSUENUMBER-FEATUREBRANCHNAME`
+1. Change to your feature branch so your changes are grouped together.
+`git checkout ISSUENUMBER-FEATUREBRANCHNAME`
+1. Update your branch (this is not needed if you just created new branch, but is a good habit to get into).
+` git pull upstream main`
+
+### Making Local Changes
+Make the code changes necessary for the issue you're working on. You will need to either redeploy your war file (see [`devops/README.md`](devops/README.md)) or redeploy your front end directly (see [`frontend.README.md`](frontend/README.md)) for testing locally. 
+
+The following git commands may prove useful.
+* `git log`: lastest commits of current branch
+* `git status`: current staged and unstaged modifications
+* `git diff --staged`:  the differences between the staging area and the last commit
+* `git add <filename>: add files that have changes to staging in preparation for commit
+* `git commit`: commits the stagged files, opens a text editor for you to write a commit log
+
+### Unit Tests
+We are working on building up test coverage. Current requirements are:
+* Do not drop the percentage of test coverage (exceptions will be made for large scale changes on case-by-case basis)
+* Do not break existing tests
+
+See [test coverage guidelines](src/test/README.md) for how to develop your tests.
+
+### Submit PR
+Up to this point, all changes have been done to your local copy of Wildbook. You need to push the new commits to a remote branch to start the PR process.
+
+1. Now's the time clean up your PR if you choose to squash commits, but this is not required. If you're looking for more information on these practices, see this [pull request tutorial](https://yangsu.github.io/pull-request-tutorial/).
+1. Push to the remote version of your branch ` git push <remote> <local branch>`
+`git push origin ISSUENUMBER-FEATUREBRANCHNAME`
+1. When prompted, provide your username and GitHub Personal Access Token. If you do not have a GitHub Personal Access Token, or do not have one with the correct permissions for your newly forked repository, you will need to [create a Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+1. Check the fork's page on GitHub to verify that you see a new branch with your added commits. You should see a line saying "This branch is X commits ahead" and a **Pull request** link. 
+1. Click the **Pull request** link to open a form that says "Able to merge". (If it says there are merge conflicts, go the  for help).
+1. Use an explicit title for the PR and provide details in the comment area. Details can include text, or images, and should provide details as to what was done and why design decisions were made.
+1. Click **Create a pull request**. 
+ 
+### Respond to feedback
+At this point, it's on us to get you feedback on your submission! Someone from the Wild Me team will review the project and provide any feedback that may be necessary. If changes are recommended, you'll need to checkout the branch you were working from, update the branch, and make these changes locally.
+
+1. `git checkout ISSUENUMBER-FEATUREBRANCHNAME`
+1. `git pull upstream main`
+1. Make required changes
+1. `git add <filename>` for all files impacted by changes
+1. Determine which method would be most appropriate for updating your PR  
+  * `git commit --ammend` if the changes are small stylistic changes
+  * `git commit` if the changes involved significant rework and require additional details
+
+

--- a/frontend/maven-build.sh
+++ b/frontend/maven-build.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Skip frontend build if running in Docker (Docker builds it separately)
+if [ "$SKIP_FRONTEND_BUILD" = "true" ]; then
+  echo "Skipping frontend build (SKIP_FRONTEND_BUILD=true)"
+  exit 0
+fi
+
 # it seems like we dont need a full/absolute url here
 #export PUBLIC_URL=https://example.com/react/
 export PUBLIC_URL=/react/
@@ -9,7 +15,7 @@ npm install react-app-rewired
 
 cd frontend
 
-# Use `npm ci` for consistent and faster installs in production, as it installs exact versions 
+# Use `npm ci` for consistent and faster installs in production, as it installs exact versions
 # from `package-lock.json` without modifying it, ensuring stability across environments.
 npm ci
 
@@ -19,9 +25,6 @@ npm run build
 
 rsync -a build/ ../src/main/webapp/react
 
-
-
 # hacky cleanup of changes left over
 cd ..
 git checkout -- package.json package-lock.json
-

--- a/pom.xml
+++ b/pom.xml
@@ -711,24 +711,9 @@
         </executions>
       </plugin>
 
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
-        <executions>
-          <execution>
-            <id>Build React Directory</id>
-            <phase>clean</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>${basedir}/frontend/maven-build.sh</executable>
-              <workingDirectory>${basedir}</workingDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+      <!-- NOTE: exec-maven-plugin that ran frontend/maven-build.sh during clean phase has been removed in Phase 0.
+           The frontend build is now independent (see frontend-build stage in Dockerfile).
+           This allows the Maven build to run without Node.js or the frontend directory present. -->
 
       <plugin>
         <groupId>org.datanucleus</groupId>

--- a/src/main/java/org/ecocean/servlet/EncounterDelete.java
+++ b/src/main/java/org/ecocean/servlet/EncounterDelete.java
@@ -5,6 +5,7 @@ import org.ecocean.grid.GridManager;
 import org.ecocean.grid.GridManagerFactory;
 import org.ecocean.ia.Task;
 import org.ecocean.servlet.importer.ImportTask;
+import org.ecocean.servlet.ReactRouter;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -194,7 +195,7 @@ public class EncounterDelete extends HttpServlet {
                     if (allStatesSize > 0) {
                         for (int i = 0; i < allStatesSize; i++) {
                             String stateName = allStates.get(i);
-                            out.println("<p><a href=\"/react/encounter-search?state=" + stateName +
+                            out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) +
                                 "\">View all " + stateName + " encounters</a></font></p>");
                         }
                     }
@@ -230,7 +231,7 @@ public class EncounterDelete extends HttpServlet {
                    if(allStatesSize>0){
                     for(int i=0;i<allStatesSize;i++){
                       String stateName=allStates.get(i);
-                      out.println("<p><a href=\"/react/encounter-search?state="+stateName+"\">View all "+stateName+" encounters</a></font></p>");
+                      out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) + "\">View all "+stateName+" encounters</a></font></p>");
                     }
                    }
                    out.println(ServletUtilities.getFooter(context));

--- a/src/main/java/org/ecocean/servlet/EncounterSetDynamicProperty.java
+++ b/src/main/java/org/ecocean/servlet/EncounterSetDynamicProperty.java
@@ -3,6 +3,7 @@ package org.ecocean.servlet;
 import org.ecocean.CommonConfiguration;
 import org.ecocean.Encounter;
 import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.servlet.ReactRouter;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -102,7 +103,7 @@ public class EncounterSetDynamicProperty extends HttpServlet {
                 if (allStatesSize > 0) {
                     for (int i = 0; i < allStatesSize; i++) {
                         String stateName = allStates.get(i);
-                        out.println("<p><a href=\"/react/encounter-search?state=" + stateName +
+                        out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) +
                             "\">View all " + stateName + " encounters</a></font></p>");
                     }
                 }
@@ -129,7 +130,7 @@ public class EncounterSetDynamicProperty extends HttpServlet {
                 if (allStatesSize > 0) {
                     for (int i = 0; i < allStatesSize; i++) {
                         String stateName = allStates.get(i);
-                        out.println("<p><a href=\"/react/encounter-search?state=" + stateName +
+                        out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) +
                             "\">View all " + stateName + " encounters</a></font></p>");
                     }
                 }
@@ -152,8 +153,8 @@ public class EncounterSetDynamicProperty extends HttpServlet {
             if (allStatesSize > 0) {
                 for (int i = 0; i < allStatesSize; i++) {
                     String stateName = allStates.get(i);
-                    out.println("<p><a href=\"/react/encounter-search?state=" + stateName +
-                        "\">View all " + stateName + " encounters</a></font></p>");
+                        out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) +
+                            "\">View all " + stateName + " encounters</a></font></p>");
                 }
             }
             out.println(

--- a/src/main/java/org/ecocean/servlet/EncounterSetObservation.java
+++ b/src/main/java/org/ecocean/servlet/EncounterSetObservation.java
@@ -15,6 +15,7 @@ import org.ecocean.Encounter;
 import org.ecocean.Observation;
 import org.ecocean.Occurrence;
 import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.servlet.ReactRouter;
 
 public class EncounterSetObservation extends HttpServlet {
     /**
@@ -126,7 +127,7 @@ public class EncounterSetObservation extends HttpServlet {
                 if (allStatesSize > 0) {
                     for (int i = 0; i < allStatesSize; i++) {
                         String stateName = allStates.get(i);
-                        out.println("<p><a href=\"/react/encounter-search?state=" + stateName +
+                        out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) +
                             "\">View all " + stateName + " Encounters</a></font></p>");
                     }
                 }
@@ -149,8 +150,8 @@ public class EncounterSetObservation extends HttpServlet {
                 if (allStatesSize > 0) {
                     for (int i = 0; i < allStatesSize; i++) {
                         String stateName = allStates.get(i);
-                        out.println("<p><a href=\"/react/encounter-search?state=" + stateName +
-                            "\">View all " + stateName + " encounters</a></font></p>");
+                    out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) +
+                        "\">View all " + stateName + " encounters</a></font></p>");
                     }
                 }
                 out.println(ServletUtilities.getFooter(context));

--- a/src/main/java/org/ecocean/servlet/EncounterSetTapirLinkExposure.java
+++ b/src/main/java/org/ecocean/servlet/EncounterSetTapirLinkExposure.java
@@ -3,6 +3,7 @@ package org.ecocean.servlet;
 import org.ecocean.CommonConfiguration;
 import org.ecocean.Encounter;
 import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.servlet.ReactRouter;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -76,8 +77,8 @@ public class EncounterSetTapirLinkExposure extends HttpServlet {
                         if (allStatesSize > 0) {
                             for (int i = 0; i < allStatesSize; i++) {
                                 String stateName = allStates.get(i);
-                                out.println("<p><a href=\"/react/encounter-search?state=" +
-                                    stateName + "\">View all " + stateName +
+                                out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) +
+                                    "\">View all " + stateName +
                                     " encounters</a></font></p>");
                             }
                         }
@@ -102,8 +103,8 @@ public class EncounterSetTapirLinkExposure extends HttpServlet {
                         if (allStatesSize > 0) {
                             for (int i = 0; i < allStatesSize; i++) {
                                 String stateName = allStates.get(i);
-                                out.println("<p><a href=\"/react/encounter-search?state=" +
-                                    stateName + "\">View all " + stateName +
+                                out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) +
+                                    "\">View all " + stateName +
                                     " encounters</a></font></p>");
                             }
                         }

--- a/src/main/java/org/ecocean/servlet/IndividualSetSex.java
+++ b/src/main/java/org/ecocean/servlet/IndividualSetSex.java
@@ -2,6 +2,7 @@ package org.ecocean.servlet;
 
 import org.ecocean.MarkedIndividual;
 import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.servlet.ReactRouter;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -120,7 +121,8 @@ public class IndividualSetSex extends HttpServlet {
                if(allStatesSize>0){
                for(int i=0;i<allStatesSize;i++){
                 String stateName=allStates.get(i);
-                out.println("<p><a href=\"/react/encounter-search?state="+stateName+"\">View all "+stateName+" encounters</a></font></p>");
+                    out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) +
+                        "\">View all " + stateName + " encounters</a></font></p>");
                }
                }*/
             // out.println("<p><a href=\"individualSearchResults.jsp\">View all individuals</a></font></p>");

--- a/src/main/java/org/ecocean/servlet/KeywordHandler.java
+++ b/src/main/java/org/ecocean/servlet/KeywordHandler.java
@@ -4,6 +4,7 @@ import org.ecocean.CommonConfiguration;
 import org.ecocean.Keyword;
 import org.ecocean.media.MediaAsset;
 import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.servlet.ReactRouter;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -65,7 +66,7 @@ public class KeywordHandler extends HttpServlet {
                 if (allStatesSize > 0) {
                     for (int i = 0; i < allStatesSize; i++) {
                         String stateName = allStates.get(i);
-                        out.println("<p><a href=\"/react/encounter-search?state=" + stateName +
+                        out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) +
                             "\">View all " + stateName + " encounters</a></font></p>");
                     }
                 }
@@ -106,7 +107,7 @@ public class KeywordHandler extends HttpServlet {
                 if (allStatesSize > 0) {
                     for (int i = 0; i < allStatesSize; i++) {
                         String stateName = allStates.get(i);
-                        out.println("<p><a href=\"/react/encounter-search?state=" + stateName +
+                        out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) +
                             "\">View all " + stateName + " encounters</a></font></p>");
                     }
                 }
@@ -145,7 +146,7 @@ public class KeywordHandler extends HttpServlet {
                 if (allStatesSize > 0) {
                     for (int i = 0; i < allStatesSize; i++) {
                         String stateName = allStates.get(i);
-                        out.println("<p><a href=\"/react/encounter-search?state=" + stateName +
+                        out.println("<p><a href=\"" + ReactRouter.path("/encounter-search?state=" + stateName) +
                             "\">View all " + stateName + " encounters</a></font></p>");
                     }
                 }

--- a/src/main/java/org/ecocean/servlet/LoginUser.java
+++ b/src/main/java/org/ecocean/servlet/LoginUser.java
@@ -17,11 +17,12 @@ import org.apache.shiro.SecurityUtils;
 
 import org.ecocean.*;
 import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.servlet.ReactRouter;
 
 /**
  * Uses JSecurity to authenticate a user If user can be authenticated successfully forwards user to /welcome.jsp
  *
- * If user cannot be authenticated then forwards user to the /react/login which will display an error message
+ * If user cannot be authenticated then forwards user to the React login page which will display an error message
  */
 public class LoginUser extends javax.servlet.http.HttpServlet implements javax.servlet.Servlet {
     static final long serialVersionUID = 1L;
@@ -36,7 +37,7 @@ public class LoginUser extends javax.servlet.http.HttpServlet implements javax.s
 
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
     throws ServletException, IOException {
-        String url = "/react/login";
+        String url = ReactRouter.path("/login");
 
         System.out.println("Starting LoginUser servlet...");
 
@@ -44,7 +45,7 @@ public class LoginUser extends javax.servlet.http.HttpServlet implements javax.s
         // if(!urlLoc.contains("localhost")) {urlLoc="https:"+urlLoc;System.out.println("HTTPS!");}
         // else {urlLoc="http:"+urlLoc;}
 
-        // see /react/login for these form fields
+        // see ReactRouter.path("/login") for these form fields
         String username = request.getParameter("username").trim();
         String password = request.getParameter("password").trim();
         String salt = "";

--- a/src/main/java/org/ecocean/servlet/ReactRouter.java
+++ b/src/main/java/org/ecocean/servlet/ReactRouter.java
@@ -1,0 +1,35 @@
+package org.ecocean.servlet;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Central configuration for the React frontend base path.
+ * Changing REACT_BASE_PATH updates every legacy link and redirect.
+ */
+public final class ReactRouter {
+    private static final String REACT_BASE_PATH = "/react";
+
+    private ReactRouter() {}
+
+    public static String getBasePath() {
+        return REACT_BASE_PATH;
+    }
+
+    public static String getBasePath(HttpServletRequest request) {
+        return request.getContextPath() + REACT_BASE_PATH;
+    }
+
+    public static String path(String route) {
+        if (route == null || route.isEmpty() || "/".equals(route)) {
+            return REACT_BASE_PATH + "/";
+        }
+        if (route.startsWith("/")) {
+            return REACT_BASE_PATH + route;
+        }
+        return REACT_BASE_PATH + "/" + route;
+    }
+
+    public static String path(HttpServletRequest request, String route) {
+        return request.getContextPath() + path(route);
+    }
+}

--- a/src/main/java/org/ecocean/servlet/UserResetPassword.java
+++ b/src/main/java/org/ecocean/servlet/UserResetPassword.java
@@ -2,6 +2,7 @@ package org.ecocean.servlet;
 
 import org.ecocean.*;
 import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.servlet.ReactRouter;
 
 // import com.oreilly.servlet.multipart.FilePart;
 // import com.oreilly.servlet.multipart.MultipartParser;
@@ -94,7 +95,7 @@ public class UserResetPassword extends HttpServlet {
                             out.println("<strong>Success:</strong> Password successfully reset.");
 
                             out.println("<p><a href=\"" + request.getScheme() + "://" +
-                                CommonConfiguration.getURLLocation(request) + "/react/login" +
+                                CommonConfiguration.getURLLocation(request) + ReactRouter.path("/login") +
                                 "\">Return to login page" + "</a></p>\n");
                             out.println(ServletUtilities.getFooter(context));
                         } else {

--- a/src/main/java/org/ecocean/servlet/importer/StandardImport.java
+++ b/src/main/java/org/ecocean/servlet/importer/StandardImport.java
@@ -21,6 +21,7 @@ import org.ecocean.identity.IBEISIA;
 import org.ecocean.importutils.*;
 import org.ecocean.media.*;
 import org.ecocean.servlet.*;
+import org.ecocean.servlet.ReactRouter;
 import org.ecocean.shepherd.core.Shepherd;
 import org.ecocean.social.Membership;
 import org.ecocean.social.SocialUnit;
@@ -506,7 +507,7 @@ public class StandardImport extends HttpServlet {
 
         String uName = request.getUserPrincipal().getName();
         if (committing && uName != null)
-            out.println("<p><a href=\"..//react/encounter-search?username=" + uName +
+            out.println("<p><a href=\"" + ReactRouter.path(request, "/encounter-search?username=" + uName) +
                 "\">Search encounters owned by current user \"" + uName + "\"</a></p>");
         out.println("</div>"); // close column
         if (!committing) {

--- a/src/main/webapp/encounters/biologicalSamples.jsp
+++ b/src/main/webapp/encounters/biologicalSamples.jsp
@@ -32,6 +32,7 @@
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 
 <%!
     //note: locIds is modified, such that it contains all the IDs we traversed
@@ -1946,7 +1947,7 @@ $('.ia-match-filter-dialog input').each(function(i, el) {
 console.log('SENDING ===> %o', data);
     wildbook.IA.getPluginByType('IBEIS').restCall(data, function(xhr, textStatus) {
 console.log('RETURNED ========> %o %o', textStatus, xhr.responseJSON.taskId);
-        wildbook.openInTab('../react/match-results?taskId=' + xhr.responseJSON.taskId);
+        wildbook.openInTab('..<%= reactBase %>/match-results?taskId=' + xhr.responseJSON.taskId);
     });
     iaMatchFilterAnnotationIds = [];  //clear it out in case user sends again from this page
     $('.ia-match-filter-dialog').hide();

--- a/src/main/webapp/encounters/encounter.jsp
+++ b/src/main/webapp/encounters/encounter.jsp
@@ -1,9 +1,10 @@
 <%@ page contentType="text/html; charset=utf-8" language="java" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 
 <%
     // get encounter number and redirect to new Encounter detail page
     String num = request.getParameter("number").replaceAll("\\+", "").trim();
-    response.sendRedirect("/react/encounter?number=" + num);
+    response.sendRedirect(request.getContextPath() + reactBase + "/encounter?number=" + num);
 
-    out.println("<meta http-equiv=\"refresh\" content=\"0; url=/react/encounter?number=" + num + "\" />");
+    out.println("<meta http-equiv=\"refresh\" content=\"0; url=" + request.getContextPath() + reactBase + "/encounter?number=" + num + "\" />");
 %>

--- a/src/main/webapp/encounters/encounterSearch.jsp
+++ b/src/main/webapp/encounters/encounterSearch.jsp
@@ -8,6 +8,7 @@
 <%@ page import="org.ecocean.FormUtilities" %>
 <%@ page import="org.ecocean.shepherd.core.Shepherd" %>
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
 <%!
@@ -227,7 +228,7 @@ $(".search-collapse-header a").click(function(){
 
 
   Shepherd myShepherd = new Shepherd(context);
-  myShepherd.setAction("/react/encounter-search");
+  myShepherd.setAction(request.getContextPath() + reactBase + "/encounter-search");
   myShepherd.beginDBTransaction();
   boolean useCustomProperties = User.hasCustomProperties(request, myShepherd); // don't want to call this a bunch
 

--- a/src/main/webapp/encounters/exportSearchResults.jsp
+++ b/src/main/webapp/encounters/exportSearchResults.jsp
@@ -2,6 +2,7 @@
          import="org.ecocean.servlet.ServletUtilities,java.util.Vector,java.util.Properties,org.ecocean.genetics.*,java.util.*,java.net.URI, org.ecocean.*" %>
 <%@ page import="org.ecocean.shepherd.core.Shepherd" %>
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 
 
 <%
@@ -119,7 +120,7 @@
 
 		 <ul id="tabmenu">
 
-		   <li><a href="/react/encounter-search?<%=request.getQueryString() %>"><%=map_props.getProperty("table")%>
+		   <li><a href="<%= request.getContextPath() + reactBase %>/encounter-search?<%=request.getQueryString() %>"><%=map_props.getProperty("table")%>
 		   </a></li>
        <li><a
          href="projectManagement.jsp?<%=request.getQueryString() %>"><%=map_props.getProperty("projectManagement")%>

--- a/src/main/webapp/encounters/mappedSearchResults.jsp
+++ b/src/main/webapp/encounters/mappedSearchResults.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html; charset=utf-8" language="java" import="org.ecocean.servlet.ServletUtilities,org.ecocean.genetics.*,java.util.*,java.net.URI, org.ecocean.*,java.util.Random" %>
 <%@ page import="org.ecocean.shepherd.core.Shepherd" %>
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 
 
 <%
@@ -478,7 +479,7 @@ if (request.getQueryString() != null) {
 
  <ul id="tabmenu">
 
-   <li><a href="/react/encounter-search?<%=request.getQueryString() %>"><%=map_props.getProperty("table")%>
+   <li><a href="<%= request.getContextPath() + reactBase %>/encounter-search?<%=request.getQueryString() %>"><%=map_props.getProperty("table")%>
    </a></li>
 
  </ul>

--- a/src/main/webapp/encounters/projectManagement.jsp
+++ b/src/main/webapp/encounters/projectManagement.jsp
@@ -9,6 +9,7 @@
          java.net.URLEncoder " %>
 <%@ page import="org.ecocean.shepherd.core.Shepherd" %>
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 
 <%
 String context="context0";
@@ -60,7 +61,7 @@ if(request.getQueryString()!=null){queryString=request.getQueryString();}
 %>
 <ul id="tabmenu">
   <li><a
-    href="/react/encounter-search?<%=queryString.replaceAll("startNum","uselessNum").replaceAll("endNum","uselessNum") %>"><%=projProps.getProperty("table")%>
+    href="<%= request.getContextPath() + reactBase %>/encounter-search?<%=queryString.replaceAll("startNum","uselessNum").replaceAll("endNum","uselessNum") %>"><%=projProps.getProperty("table")%>
   </a></li>
   <li><a class="active"
     href="projectManagement.jsp?<%=queryString.replaceAll("startNum","uselessNum").replaceAll("endNum","uselessNum") %>"><%=projProps.getProperty("projectManagement")%>

--- a/src/main/webapp/encounters/searchResultsAnalysis.jsp
+++ b/src/main/webapp/encounters/searchResultsAnalysis.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html; charset=utf-8" language="java"
          import="org.ecocean.servlet.ServletUtilities,java.text.DecimalFormat,org.ecocean.Util.MeasurementDesc,org.apache.commons.math.stat.descriptive.SummaryStatistics,java.util.Vector,java.util.Properties,org.ecocean.genetics.*,java.util.*,java.net.URI, org.ecocean.*, org.ecocean.security.Collaboration" %>
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 
 <%
 String context="context0";
@@ -129,7 +130,7 @@ td.tdw:hover div {
 
  <ul id="tabmenu">
 
-   <li><a href="/react/encounter-search?<%=request.getQueryString() %>"><%=encprops.getProperty("table")%>
+   <li><a href="<%= request.getContextPath() + reactBase %>/encounter-search?<%=request.getQueryString() %>"><%=encprops.getProperty("table")%>
    </a></li>
 
  </ul>

--- a/src/main/webapp/encounters/thumbnailSearchResults.jsp
+++ b/src/main/webapp/encounters/thumbnailSearchResults.jsp
@@ -2,6 +2,7 @@
 		language="java"
  		import="org.ecocean.servlet.ServletUtilities,javax.jdo.Query,com.drew.imaging.jpeg.JpegMetadataReader,com.drew.metadata.Metadata, com.drew.metadata.Tag, org.ecocean.mmutil.MediaUtilities,org.ecocean.*,java.io.File, java.util.*,org.ecocean.security.Collaboration, java.io.FileInputStream, javax.jdo.Extent" %>
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 <%
 
   String context="context0";
@@ -210,7 +211,7 @@
 <ul id="tabmenu">
 
   <li><a
-    href="/react/encounter-search?<%=rq.replaceAll("startNum","uselessNum").replaceAll("endNum","uselessNum") %>"><%=encprops.getProperty("table")%>
+    href="<%= request.getContextPath() + reactBase %>/encounter-search?<%=rq.replaceAll("startNum","uselessNum").replaceAll("endNum","uselessNum") %>"><%=encprops.getProperty("table")%>
   </a></li>
 	<li><a
     href="projectManagement.jsp?<%=rq.replaceAll("startNum","uselessNum").replaceAll("endNum","uselessNum") %>"><%=encprops.getProperty("projectManagement")%>

--- a/src/main/webapp/header.jsp
+++ b/src/main/webapp/header.jsp
@@ -18,7 +18,8 @@
   --%>
 <!DOCTYPE html>
 <html>
-<%@ page contentType="text/html; charset=utf-8" language="java"
+<%@
+      page contentType="text/html; charset=utf-8" language="java"
      import="org.ecocean.shepherd.core.ShepherdProperties,
              org.ecocean.servlet.ServletUtilities,
              org.ecocean.CommonConfiguration,
@@ -36,7 +37,7 @@
              org.apache.logging.log4j.Logger
               "
 %>
-
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 <%
     if ("logout".equals(request.getParameter("action"))) {
         System.out.println("Logging out");
@@ -52,7 +53,7 @@
         }
         session.invalidate();
 
-        response.sendRedirect(request.getContextPath() + "/react/login/");
+        response.sendRedirect(request.getContextPath() + reactBase + "/login/");
         return;
     }
 %>
@@ -404,7 +405,7 @@ if(request.getUserPrincipal()!=null){
                 var action = $(element).data('action');
 
                 if (action === 'login'){
-                     window.open('<%=urlLoc %>/react/login/', '_blank');
+                     window.open('<%= urlLoc + reactBase %>/login/', '_blank');
                 }
                 else {
 
@@ -580,7 +581,7 @@ if(request.getUserPrincipal()!=null){
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><%=props.getProperty("submit")%> <span class="svg-placeholder"></span></a>
                         <ul class="dropdown-menu" role="menu">
 
-                            <li><a href="<%=urlLoc %>/react/report" ><%=props.getProperty("report")%></a></li>
+                            <li><a href="<%= urlLoc + reactBase %>/report" ><%=props.getProperty("report")%></a></li>
 <% if (Util.booleanNotFalse(CommonConfiguration.getProperty("showClassicSubmit", context))) { %>
                             <li><a href="<%=urlLoc %>/submit.jsp" ><%=props.getProperty("reportClassic")%></a></li>
 <% } %>
@@ -589,30 +590,30 @@ if(request.getUserPrincipal()!=null){
                               <li class="dropdown"><a href="<%=urlLoc %>/surveys/createSurvey.jsp"><%=props.getProperty("createSurvey")%></a></li>
                             -->
 
-                            <li class="dropdown"><a href="<%=urlLoc %>/react/bulk-import"><%=props.getProperty("bulkImport")%></a></li>
+                            <li class="dropdown"><a href="<%= urlLoc + reactBase %>/bulk-import"><%=props.getProperty("bulkImport")%></a></li>
                         </ul>
                       </li>
                       <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><%=props.getProperty("Resources")%><span class="svg-placeholder"></span></a>
                         <ul class="dropdown-menu" role="menu">  
                            <li><a href="https://wildbook.docs.wildme.org/"><%=props.getProperty("WildbookDocumentation")%></a></li>
-                          <li><a href="<%=urlLoc %>/react/about-us"><%=props.getProperty("AboutUs")%></a></li>
+                          <li><a href="<%= urlLoc + reactBase %>/about-us"><%=props.getProperty("AboutUs")%></a></li>
                           <li><a href="<%=urlLoc %>/contactus.jsp"><%=props.getProperty("contactUs")%></a></li>
                           <li class="dropdown-submenu">
-                            <a href="<%=urlLoc %>/react/policies-and-data?section=privacy_policy">
+                            <a href="<%= urlLoc + reactBase %>/policies-and-data?section=privacy_policy">
                               <%=props.getProperty("policiesAndData")%>
                               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
                                 <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
                               </svg>
                             </a>
                             <ul class="dropdown-menu">
-                              <li><a href="<%=urlLoc %>/react/policies-and-data?section=privacy_policy"><%=props.getProperty("privacyPolicy")%></a></li>
-                              <li><a href="<%=urlLoc %>/react/policies-and-data?section=terms_of_use"><%=props.getProperty("termsOfUse")%></a></li>
-                              <li><a href="<%=urlLoc %>/react/policies-and-data?section=citing_wildbook"><%=props.getProperty("citingWildbook")%></a></li>
+                              <li><a href="<%= urlLoc + reactBase %>/policies-and-data?section=privacy_policy"><%=props.getProperty("privacyPolicy")%></a></li>
+                              <li><a href="<%= urlLoc + reactBase %>/policies-and-data?section=terms_of_use"><%=props.getProperty("termsOfUse")%></a></li>
+                              <li><a href="<%= urlLoc + reactBase %>/policies-and-data?section=citing_wildbook"><%=props.getProperty("citingWildbook")%></a></li>
                             </ul>
                           </li>
                           <% if (Util.booleanNotFalse(CommonConfiguration.getProperty("showHowToPhotograph", context))) { %>
-                            <li><a href="<%=urlLoc %>/react/how-to-photograph"><%=props.getProperty("howToPhotograph")%></a></li>
+                            <li><a href="<%= urlLoc + reactBase %>/how-to-photograph"><%=props.getProperty("howToPhotograph")%></a></li>
                           <% } %>
                           <%-- <li><a target="_blank" href="https://www.wildme.org/#/wildbook"><%=props.getProperty("learnAboutShepherd")%></a></li> --%>
                                                   <%-- <li class="divider"></li> --%>
@@ -623,16 +624,16 @@ if(request.getUserPrincipal()!=null){
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><%=props.getProperty("Data")%> <span class="svg-placeholder"></span></a>
                         <ul class="dropdown-menu" role="menu">
                           <li class="dropdown-submenu">
-                            <a class="d-flex align-items-center justify-space-between" tabindex="-1" href="<%=urlLoc %>/react/encounter-search?username=<%=request.getRemoteUser()%>"><%=props.getProperty("myEncounters")%>
+                            <a class="d-flex align-items-center justify-space-between" tabindex="-1" href="<%= urlLoc + reactBase %>/encounter-search?username=<%=request.getRemoteUser()%>"><%=props.getProperty("myEncounters")%>
                               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
                               <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
                             </svg>
                             </a>
                             
                             <ul class="dropdown-menu">
-                                <li><a href="<%=urlLoc %>/react/encounter-search?username=<%=request.getRemoteUser()%>&state=approved"><%=props.getProperty("myApprovedAnimals")%></a></li>
-                                <li><a href="<%=urlLoc %>/react/encounter-search?username=<%=request.getRemoteUser()%>&state=unapproved"><%=props.getProperty("myUnapprovedAnimals")%></a></li>
-                                <li><a href="<%=urlLoc %>/react/encounter-search?username=<%=request.getRemoteUser()%>&state=unidentifiable"><%=props.getProperty("myUnidentifiableAnimals")%></a></li> 
+                                <li><a href="<%= urlLoc + reactBase %>/encounter-search?username=<%=request.getRemoteUser()%>&state=approved"><%=props.getProperty("myApprovedAnimals")%></a></li>
+                                <li><a href="<%= urlLoc + reactBase %>/encounter-search?username=<%=request.getRemoteUser()%>&state=unapproved"><%=props.getProperty("myUnapprovedAnimals")%></a></li>
+                                <li><a href="<%= urlLoc + reactBase %>/encounter-search?username=<%=request.getRemoteUser()%>&state=unidentifiable"><%=props.getProperty("myUnidentifiableAnimals")%></a></li> 
                           
                             </ul>
                             </li>
@@ -640,16 +641,16 @@ if(request.getUserPrincipal()!=null){
                           <li><a href="<%=urlLoc %>/individualSearchResults.jsp?username=<%=request.getRemoteUser()%>"><%=props.getProperty("myIndividuals")%></a></li>
                           <li><a href="<%=urlLoc %>/occurrenceSearchResults.jsp?submitterID=<%=request.getRemoteUser()%>"><%=props.getProperty("mySightings")%></a></li>
                           <li><a href="<%=urlLoc %>/imports.jsp"><%=props.getProperty("myBulkImports")%></a></li>
-                          <li><a href="<%=urlLoc %>/react/projects/overview"><%=props.getProperty("myProjects")%></a></li>
+                          <li><a href="<%= urlLoc + reactBase %>/projects/overview"><%=props.getProperty("myProjects")%></a></li>
                           <li><a href="<%=urlLoc %>/gallery.jsp"><%=props.getProperty("individualGallery")%></a></li>
-                          <li><a href="<%=urlLoc %>/react/encounter-search?calendar=true"><%=props.getProperty("encounterCalendar")%></a></li>    
+                          <li><a href="<%= urlLoc + reactBase %>/encounter-search?calendar=true"><%=props.getProperty("encounterCalendar")%></a></li>    
 
                         </ul>
                       </li>
                       <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><%=props.getProperty("search")%><span class="svg-placeholder"></span> </a>
                         <ul class="dropdown-menu" role="menu">
-                          <li><a href="<%=urlLoc %>/react/encounter-search"><%=props.getProperty("encounters")%></a></li>
+                          <li><a href="<%= urlLoc + reactBase %>/encounter-search"><%=props.getProperty("encounters")%></a></li>
 <% if (Util.booleanNotFalse(CommonConfiguration.getProperty("showClassicEncounters", context))) { %>
                             <li><a href="<%=urlLoc %>/encounters/encounterSearch.jsp" ><%=props.getProperty("encountersClassic")%></a></li>
 <% } %>
@@ -664,7 +665,7 @@ if(request.getUserPrincipal()!=null){
 
                           <li><a href="<%=urlLoc %>/appadmin/users.jsp?context=context0"><%=props.getProperty("userManagement")%></a></li>
                           <li><a href="<%=urlLoc %>/appadmin/admin.jsp"><%=props.getProperty("libraryAdministration")%></a></li>
-                          <li><a href="<%=urlLoc %>/react/admin/logs"><%=props.getProperty("logs")%></a></li>
+                          <li><a href="<%= urlLoc + reactBase %>/admin/logs"><%=props.getProperty("logs")%></a></li>
                           <li><a href="<%=urlLoc %>/appadmin/kwAdmin.jsp"><%=props.getProperty("photoKeywords")%></a></li>
                           <li><a href="https://wildbook.docs.wildme.org"><%=props.getProperty("softwareDocumentation")%></a></li>
                           <li><a href="<%=urlLoc %>/appadmin/dataIntegrity.jsp"><%=props.getProperty("dataIntegrity")%></a></li>
@@ -787,7 +788,7 @@ if(request.getUserPrincipal()!=null){
                                   <div class="profile-icon" style="background-image: url('<%=profilePhotoURL %>');"></div>
                                   
                                   <ul class="dropdown-menu">
-                                      <li><a href="<%=urlLoc %>/react/">Landing Page</a></li>
+                                      <li><a href="<%= urlLoc + reactBase %>/">Landing Page</a></li>
                                       <li><a href="<%=urlLoc %>/myAccount.jsp">User Profile</a></li>
                                       <li><a href="#" onclick="logoutAndRedirect()">Logout</a></li>
                                   </ul>   
@@ -799,7 +800,7 @@ if(request.getUserPrincipal()!=null){
                           }
                           else{
                             %>
-                              <a href="<%= request.getContextPath() %>/react/login/" title="" style="white-space: nowrap"><%= props.getProperty("login") %></a>
+                              <a href="<%= request.getContextPath() + reactBase %>/login/" title="" style="white-space: nowrap"><%= props.getProperty("login") %></a>
                         <%
                           }
 

--- a/src/main/webapp/iaResults.jsp
+++ b/src/main/webapp/iaResults.jsp
@@ -18,6 +18,7 @@ java.util.ArrayList,org.ecocean.Annotation, org.ecocean.Encounter,
 org.dom4j.Document, org.dom4j.Element,org.dom4j.io.SAXReader, org.ecocean.*, org.ecocean.grid.MatchComparator, org.ecocean.grid.MatchObject, java.io.File, java.util.Arrays, java.util.Iterator, java.util.List, java.util.Vector, java.nio.file.Files, java.nio.file.Paths, java.nio.file.Path" %>
 <%@ page import="org.ecocean.shepherd.core.Shepherd" %>
 <%@ page import="org.ecocean.shepherd.core.ShepherdPMF" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 
 
 <%
@@ -2009,7 +2010,7 @@ function isProjectSelected() {
 
 $('#projectDropdown').on('change', function() {
 	let taskId = '<%=taskId%>';
-	let reloadURL = "../react/match-results?taskId="+taskId;
+	let reloadURL = "..<%= reactBase %>/match-results?taskId="+taskId;
 	let selectedProject = $("#projectDropdown").val();
 	// replace reserved pound sign in incremental ID's
 	selectedProject = selectedProject.replaceAll("#", "%23");

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -12,6 +12,7 @@
 %>
 <%@ page import="org.ecocean.shepherd.core.Shepherd" %>
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 
 
 <jsp:include page="header.jsp" flush="true"/>
@@ -61,7 +62,7 @@ int numUsers=0;
 myShepherd.beginDBTransaction();
 QueryCache qc=QueryCacheFactory.getQueryCache(context);
 
-//String url = "/react/login";
+//String url = request.getContextPath() + reactBase + "/login";
 //response.sendRedirect(url);
 //RequestDispatcher dispatcher = getServletContext().getRequestDispatcher(url);
 //dispatcher.forward(request, response);
@@ -351,7 +352,7 @@ h2.vidcap {
                         %>
 
                     </ul>
-                    <a href="/react/encounter-search?state=approved" title="" class="cta"><%=props.getProperty("seeMoreEncs") %></a>
+                    <a href="<%= request.getContextPath() + reactBase %>/encounter-search?state=approved" title="" class="cta"><%=props.getProperty("seeMoreEncs") %></a>
                 </div>
             </section>
             <section class="col-xs-12 col-sm-6 col-md-4 col-lg-4 padding focusbox">

--- a/src/main/webapp/individuals.jsp
+++ b/src/main/webapp/individuals.jsp
@@ -13,6 +13,7 @@ org.datanucleus.api.rest.RESTUtils, org.datanucleus.api.jdo.JDOPersistenceManage
 
 
 <%!
+  String reactBase = org.ecocean.servlet.ReactRouter.getBasePath();
   public static ArrayList<org.datanucleus.api.rest.orgjson.JSONObject> getExemplarImagesFast(MarkedIndividual thisIndiv, Shepherd myShepherd, HttpServletRequest req, int numResults, String imageSize) throws JSONException {
     ArrayList<org.datanucleus.api.rest.orgjson.JSONObject> al=new ArrayList<org.datanucleus.api.rest.orgjson.JSONObject>();
 
@@ -1211,7 +1212,7 @@ if (sharky.getNames() != null) {
         -1px 1px 0 #000,
         1px 1px 0 #000;
     ">
-    <p class="viewAllImgs"><a style="color:white;" href="/react/encounter-search?individualIDExact=<%=sharky.getIndividualID()%>"><%=props.getProperty("allImages")%></a></p></div>
+    <p class="viewAllImgs"><a style="color:white;" href="<%= request.getContextPath() + reactBase %>/encounter-search?individualIDExact=<%=sharky.getIndividualID()%>"><%=props.getProperty("allImages")%></a></p></div>
 
 
     <div class="slider col-sm-6 center-slider">

--- a/src/main/webapp/logout.jsp
+++ b/src/main/webapp/logout.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html; charset=utf-8" language="java"
          import="org.ecocean.servlet.ServletUtilities,org.ecocean.*, java.util.Properties" %>
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 <%
 
 String context="context0";
@@ -36,7 +37,7 @@ context=ServletUtilities.getContext(request);
         
 
         <p><%=props.getProperty("loggedOut") %></p>
-        <p><a href="<%= request.getContextPath() %>/react/login/"><%=props.getProperty("clickHere") %></a></p>
+        <p><a href="<%= request.getContextPath() + reactBase %>/login/"><%=props.getProperty("clickHere") %></a></p>
         
 
         <p>&nbsp;</p>

--- a/src/main/webapp/myAccount.jsp
+++ b/src/main/webapp/myAccount.jsp
@@ -5,6 +5,7 @@ javax.servlet.http.HttpSession,
 java.io.*" %>
 <%@ page import="org.ecocean.shepherd.core.Shepherd" %>
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 
 
 <%
@@ -599,7 +600,7 @@ java.io.*" %>
 		<p><strong><%=props.getProperty("links2mydata") %></strong></p>
 		<p class="caption"><a href="individualSearchResultsAnalysis.jsp?username=<%=localUsername%>"><%=props.getProperty("individualsAssociated") %></a></p>
 
-		<p class="caption"><a href="/react/encounter-search?username=<%=localUsername%>"><%=props.getProperty("encountersAssociated") %></a></p>
+		<p class="caption"><a href="<%= request.getContextPath() + reactBase %>/encounter-search?username=<%=localUsername%>"><%=props.getProperty("encountersAssociated") %></a></p>
 
 
 			<%

--- a/src/main/webapp/projects/project.jsp
+++ b/src/main/webapp/projects/project.jsp
@@ -14,6 +14,7 @@
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 
 <%
   String context="context0";
@@ -69,7 +70,7 @@
 	      		<div class="row">
 	        		<div class="col-xs-10 col-sm-10 col-md-10 col-lg-10 col-xl-10">
 	          			<h3><%= projectProps.getProperty("ProjectColon")%> <%=project.getResearchProjectName()%></h3>
-	          			<p><%= projectProps.getProperty("EncounterDirectionsPt1")%><a target="_new" href="/react/encounter-search"> <%= projectProps.getProperty("EncounterDirectionsPt2")%></a><%= projectProps.getProperty("EncounterDirectionsPt3")%></p>
+	          			<p><%= projectProps.getProperty("EncounterDirectionsPt1")%><a target="_new" href="<%= request.getContextPath() + reactBase %>/encounter-search"> <%= projectProps.getProperty("EncounterDirectionsPt2")%></a><%= projectProps.getProperty("EncounterDirectionsPt3")%></p>
 	        		</div>
 	        	<div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 col-xl-10">
 	          	<span id="editButtonSpan"></span>
@@ -550,7 +551,7 @@ function removeEncounterFromProjectAjax(el) {
 
 function goToIAResults(taskId) {
 	  let projectIdPrefix = '<%= project.getProjectIdPrefix()%>';
-	  window.open('/react/match-results?taskId='+taskId+'&projectIdPrefix='+encodeURIComponent(projIdPrefix), "_blank");
+	  window.open('<%= request.getContextPath() + reactBase %>/match-results?taskId='+taskId+'&projectIdPrefix='+encodeURIComponent(projIdPrefix), "_blank");
 }
 
 function generateIALinkingMenu(json, encId) {

--- a/src/main/webapp/submit.jsp
+++ b/src/main/webapp/submit.jsp
@@ -7,6 +7,7 @@
                  java.util.Locale" %>
 <%@ page import="org.ecocean.shepherd.core.Shepherd" %>
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
+<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>
 
 
 <!-- Add reCAPTCHA -->
@@ -1447,7 +1448,7 @@ function sendButtonClicked() {
           <label for="agreeToTerms" style="font-weight: normal; margin: 0;">
             I agree to
             <a
-              href="<%=request.getContextPath()%>/react/policies-and-data?section=terms_of_use"
+              href="<%=request.getContextPath()%><%= reactBase %>/policies-and-data?section=terms_of_use"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -1455,7 +1456,7 @@ function sendButtonClicked() {
             </a>
             and
             <a
-              href="<%=request.getContextPath()%>/react/policies-and-data?section=privacy_policy"
+              href="<%=request.getContextPath()%><%= reactBase %>/policies-and-data?section=privacy_policy"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/test/java/org/ecocean/servlet/ReactRouterTest.java
+++ b/src/test/java/org/ecocean/servlet/ReactRouterTest.java
@@ -1,0 +1,77 @@
+package org.ecocean.servlet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.Test;
+
+class ReactRouterTest {
+
+    private static HttpServletRequest reqWithContextPath(String ctx) {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getContextPath()).thenReturn(ctx);
+        return req;
+    }
+
+    @Test void getBasePath_returnsReact() {
+        assertEquals("/react", ReactRouter.getBasePath());
+    }
+
+    @Test void getBasePath_withRequest_rootContext() {
+        HttpServletRequest req = reqWithContextPath("");
+        assertEquals("/react", ReactRouter.getBasePath(req));
+    }
+
+    @Test void getBasePath_withRequest_nonRootContext() {
+        HttpServletRequest req = reqWithContextPath("/wildbook");
+        assertEquals("/wildbook/react", ReactRouter.getBasePath(req));
+    }
+
+    @Test void getBasePath_withRequest_nullContext() {
+        HttpServletRequest req = reqWithContextPath(null);
+        assertEquals("null/react", ReactRouter.getBasePath(req));
+    }
+
+    @Test void path_nullRoute_returnsTrailingSlash() {
+        assertEquals("/react/", ReactRouter.path(null));
+    }
+
+    @Test void path_emptyRoute_returnsTrailingSlash() {
+        assertEquals("/react/", ReactRouter.path(""));
+    }
+
+    @Test void path_rootOnly_returnsTrailingSlash() {
+        assertEquals("/react/", ReactRouter.path("/"));
+    }
+
+    @Test void path_leadingSlashRoute() {
+        assertEquals("/react/login", ReactRouter.path("/login"));
+    }
+
+    @Test void path_noLeadingSlashRoute() {
+        assertEquals("/react/login", ReactRouter.path("login"));
+    }
+
+    @Test void path_nestedRoute_withLeadingSlash() {
+        assertEquals("/react/encounter-search?state=approved",
+            ReactRouter.path("/encounter-search?state=approved"));
+    }
+
+    @Test void path_withRequest_rootContext() {
+        HttpServletRequest req = reqWithContextPath("");
+        assertEquals("/react/login", ReactRouter.path(req, "/login"));
+    }
+
+    @Test void path_withRequest_nonRootContext() {
+        HttpServletRequest req = reqWithContextPath("/wildbook");
+        assertEquals("/wildbook/react/login", ReactRouter.path(req, "/login"));
+    }
+
+    @Test void path_withRequest_nullContext() {
+        HttpServletRequest req = reqWithContextPath(null);
+        assertEquals("null/react/login", ReactRouter.path(req, "/login"));
+    }
+}


### PR DESCRIPTION
This is the first PR in a progressive strangler-fig migration to separate the React SPA from the
monolithic Java/Tomcat WAR. Previously, Maven built React via `exec-maven-plugin` into
`src/main/webapp/react/` inside the WAR, and Tomcat served everything — JSPs, API, and the SPA
— from a single context.

After this PR, React runs in its own container with CRA dev server live reload, Caddy acts as
a unified reverse proxy, the WAR no longer contains any React build artifacts, and all 26 legacy
hardcoded `/react/` references are centralized into a single `ReactRouter` class.

---

## Architecture (after this PR)

```
Browser → :80 (Caddy)
              ├─ /api/*     → tomcat:8080  (Java API — no path stripping)
              ├─ /react/*   → frontend:3000 (CRA dev server, livereload)
              └─ /*         → tomcat:8080  (JSPs, legacy servlets)
```

- **Development**: edit `frontend/src/` → Webpack recompiles → browser refreshes automatically.
- **Production**: CRA `npm run build` → serve static files; no changes needed to the Caddyfile.

---

## Files changed

### New files (3)

| File | Purpose |
|---|---|
| `src/main/java/org/ecocean/servlet/ReactRouter.java` | Single source of truth for the React base path (`/react`). Changing the constant `REACT_BASE_PATH` updates every legacy link in one place. |
| `src/test/java/org/ecocean/servlet/ReactRouterTest.java` | 13 unit tests covering `getBasePath()`, `getBasePath(req)`, `path(route)`, and `path(req, route)` with root and non-root context paths. |
| `devops/development/.dockerfiles/frontend/Dockerfile` | Standalone React container with CRA dev server. Volume-mounts `frontend/src/` and `config-overrides.js` for livereload. |

### Java servlets refactored (9)

All used hardcoded `"/react/"` strings to link to the React SPA from legacy HTML responses. Each now delegates to `ReactRouter.path(...)`.

| File | Lines changed | What was replaced |
|---|---|---|
| `EncounterSetDynamicProperty.java` | 3 sites | `"/react/encounter-search?state="` → `ReactRouter.path("/encounter-search?state=" + stateName)` |
| `LoginUser.java` | 1 site | `"/react/login"` → `ReactRouter.path("/login")` |
| `IndividualSetSex.java` | 1 site (commented) | `"/react/encounter-search?state="` → `ReactRouter.path(...)` |
| `EncounterSetTapirLinkExposure.java` | 2 sites | `"/react/encounter-search?state="` → `ReactRouter.path(...)` |
| `EncounterSetObservation.java` | 2 sites | `"/react/encounter-search?state="` → `ReactRouter.path(...)` |
| `KeywordHandler.java` | 3 sites | `"/react/encounter-search?state="` → `ReactRouter.path(...)` |
| `EncounterDelete.java` | 2 sites (1 active, 1 commented) | `"/react/encounter-search?state="` → `ReactRouter.path(...)` |
| `StandardImport.java` | 1 site | `"/react/encounter-search?username="` → `ReactRouter.path(request, "/encounter-search?username=" + uName)` (uses 2-arg overload with context path) |
| `UserResetPassword.java` | 1 site | `"/react/login"` → `ReactRouter.path("/login")` |

### JSP files refactored (16)

Each JSP declares `<%! String reactBase = org.ecocean.servlet.ReactRouter.getBasePath(); %>` and uses `<%= reactBase %>` instead of hardcoded `"/react/"`:

`header.jsp`, `submit.jsp`, `logout.jsp`, `myAccount.jsp`, `projects/project.jsp`, `individuals.jsp`, `iaResults.jsp`, `encounters/mappedSearchResults.jsp`, `encounters/searchResultsAnalysis.jsp`, `encounters/exportSearchResults.jsp`, `encounters/encounter.jsp`, `encounters/biologicalSamples.jsp`, `index.jsp`, `encounters/thumbnailSearchResults.jsp`, `encounters/projectManagement.jsp`, `encounters/encounterSearch.jsp`

(~37 total replacement sites across 16 JSPs)

### Build / infra refactored

| File | Change |
|---|---|
| `pom.xml` | Removed `exec-maven-plugin` that ran `frontend/maven-build.sh` during `clean` phase. React is no longer a Maven concern. |
| `Dockerfile` (wildbook) | Removed `frontend-build` stage and `COPY --from=frontend-build`. Added `rm -rf /app/src/main/webapp/react` to prevent stale host files leaking into the WAR. |
| `Caddyfile` | Split from single pass-through to three-route proxy (API / React / legacy). `/react/*` proxies to CRA dev server; everything else proxies to Tomcat. |
| `Caddy Dockerfile` | Stripped to pure `caddy:2-alpine` + Caddyfile. No longer builds React. |
| `docker-compose.yml` | Added `frontend` service (Node 18, port 3000, volume mounts for livereload). `proxy` depends on both `wildbook` and `frontend`. |
| `tomcat/server.xml` | Fixed `docBase` from `"wildbook"` to `"ROOT"` to match how the Dockerfile deploys the WAR. |
| `tomcat/wildbook-start.sh` | Added symlink `webapps/wildbook → ROOT` so ImageMagick watermark path resolves correctly. |

### Deleted / archived

| Artifact | Reason |
|---|---|
| `src/main/webapp/react/` (in WAR) | React is no longer bundled into the WAR. Caddy or a dedicated container serves it. |
| `frontend/maven-build.sh` | No longer invoked by Maven. Kept on disk in case an external CI step still references it. |

### Files intentionally NOT modified

`ReactAppServlet.java`, `web.xml`, nginx configs, frontend JavaScript/JSX.

---

## Verification

- **Unit tests**: 32/32 servlet-path tests pass (13 `ReactRouterTest` + 19 `ReactAppServletTest`)
- **Build**: `mvn clean install` succeeds. `ROOT.war` contains **zero** `/react/` files.
- **Behave health checks**: Wildbook homepage (200), Wildbook contains "Wildbook", OpenSearch healthy, service-to-service communication verified.
- **Browser E2E (Puppeteer)**: Auth suite 5/5 pass (login, logout, protected routes via Caddy proxy).
